### PR TITLE
A few quick dev hacks.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ module.exports = {
       devDependencies: ['nyc'],
       scriptName: 'test',
       scriptCommand: 'nyc --reporter=lcov node test/',
-      scriptCommandVariants: ['node test/', 'tape test/**/*.js', 'node test/**/*.js']
+      scriptCommandVariants: ['node test/', 'tape test/**/*.js', 'node test/**/*.js', 'react-scripts test --env=jsdom']
     }),
     new ScriptRule({
       name: 'cover it!',
@@ -213,18 +213,18 @@ module.exports = {
       scriptCommand: 'node scripts/check-licenses.js'
     }),
 
-    // filenames! kebab 'em
-    new FilenameRule({
-      name: 'kebab case it!',
-      fileFormatExtensions: 'js',
-      fileFormatFunction: kebab
-    }),
+    // // filenames! kebab 'em
+    // new FilenameRule({
+    //   name: 'kebab case it!',
+    //   fileFormatExtensions: 'js',
+    //   fileFormatFunction: kebab
+    // }),
 
-    // tie 'em up!
-    new PreCommitRule({
-      name: 'precommit quality it!',
-      preCommitTasks: ['validate', 'lint', 'test', 'check-coverage', 'check-licenses', 'secure']
-    })
+    // // tie 'em up!
+    // new PreCommitRule({
+    //   name: 'precommit quality it!',
+    //   preCommitTasks: ['validate', 'lint', 'test', 'check-coverage', 'check-licenses', 'secure']
+    // })
   ],
 
   /**


### PR DESCRIPTION
1) Allow the create-react-app test target as a valid test rule.
2) Disable the git hooks since we run in an environment where the project isn't at the same level as the .git folder.
3) Disable the kebab-case file naming check since we're not sure that that's the rule we want to standardise upon.

Note that I don't expect you to take this PR, it's simply a document to go with the discussion we just had :)
